### PR TITLE
feat: Add first implementation version with basic functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,7 @@ Rust macros for deriving optional types
 keywords = ["macro", "derive", "macros"]
 categories = ["rust-patterns"]
 license = "MIT OR Apache-2.0"
-include = [
-  "src/*",
-  "Cargo.toml"
-]
+include = ["src/*", "Cargo.toml"]
 
 [lib]
 proc_macro = true
@@ -22,5 +19,4 @@ proc_macro = true
 [dependencies]
 syn = ">= 2.0.13"
 quote = ">= 1.0.26"
-proc-macro2 = "1.0.56"
-
+proc-macro2 = "1.0.105"

--- a/examples/playground.rs
+++ b/examples/playground.rs
@@ -1,15 +1,16 @@
 use optifier;
 
 #[derive(optifier::Partial)]
+#[derive(Debug)]
 struct TestType {
     field_i32: i32,
     field_string: String,
+    field_option_string: Option<String>,
 }
 
 fn main() -> Result<(), ()> {
-    let _complete = TestType { field_i32: 42, field_string: String::from("Hello world") };
-    let partial = TestTypePartial { field_i32_opt: Some(42), field_string_opt: Some(String::from("hello world")) };
+    let _complete = TestType { field_i32: 42, field_string: String::from("Hello world"), field_option_string: Some(String::from("Hello world")) };
+    let partial = TestTypePartial { field_i32: Some(42), field_string: Some(String::from("hello world")), field_option_string: Some(String::from("hello world")) };
     dbg!(partial);
     return Ok(());
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,146 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
+//! Proc macro crate: `Partial` derive
+//!
+//! Derive `Partial` on a struct `Foo` to generate a new struct named `FooPartial`
+//! where every field type is wrapped in `Option<T>` unless it is already an `Option<T>`.
+//! Only structs with named fields are accepted; tuple and unit structs are not supported.
+//!
+//! Example:
+//! ```ignore
+//! #[derive(Partial)]
+//! pub struct Foo {
+//!     a: i32,
+//!     b: Option<String>,
+//!     pub c: Vec<u8>,
+//! }
+//! ```
+//! expands to:
+//! ```ignore
+//! pub struct FooPartial {
+//!     a: Option<i32>,
+//!     b: Option<String>, // stays as-is
+//!     pub c: Option<Vec<u8>>,
+//! }
+//! ```
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use syn::{
+    Data, DeriveInput, Ident, Path, PathArguments, Type, TypePath, Visibility, parse_macro_input
+};
+
+/// Derive macro to generate a `*Partial` variant of a struct with all fields wrapped in `Option`.
+///
+/// Put `#[derive(optifier::Partial)]` on a struct item. The macro will output:
+/// - A new struct `<OriginalName>Partial` with the same visibility and field names, but with each
+///   field type wrapped in `Option<T>`, unless it is already `Option<...>`.
+///
+///! Supported:
+///! - Named-field structs
+///
+///! Not supported:
+///! - Tuple structs
+///! - Unit structs
+///
+/// Notes:
+/// - Generic parameters and lifetimes are copied as-is to the generated `Partial` struct.
+/// - Field-level visibilities are preserved.
+/// - Field attributes are not copied to the generated struct (to avoid duplicating derives/etc.).
+#[proc_macro_derive(Partial)]
+pub fn derive_partial(item: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(item as DeriveInput);
+
+    let orig_vis: Visibility = input.vis.clone();
+    let orig_ident: Ident = input.ident.clone();
+    let partial_ident = format_ident!("{}Partial", orig_ident);
+    let maybe_derive_attr = deduce_derive_attr(&input);
+
+    let Data::Struct(input_struct) = input.data else {
+        panic!("Optifier supports only struct types");
+    };
+
+    // Copy generics from original to partial
+    let generics = input.generics.clone();
+    let (_impl_generics, _ty_generics, where_clause) = generics.split_for_impl();
+
+    // Currently we support only named fields inside a structure.
+    // Support for tuple structs will be added in the future.
+    //
+    // Generate fields for the partial struct by wrapping types in Option if needed
+
+
+    let syn::Fields::Named(fields) = &input_struct.fields else {
+        panic!("Optifier supports only named fields");
+    };
+
+   let partial_fields = fields.named.iter().map(|f| {
+        let f_vis = &f.vis;
+        let f_ident = f.ident.as_ref().expect("Optifier: Named field must have ident");
+        let f_ty = &f.ty;
+        if is_option_type(f_ty) {
+            quote! {
+                #f_vis #f_ident: #f_ty
+            }
+        } else {
+            quote! {
+                #f_vis #f_ident: std::option::Option<#f_ty>
+            }
+        }
+    });
+
+    let struct_def = quote! {
+        #maybe_derive_attr
+        #orig_vis struct #partial_ident #generics {
+            #(#partial_fields),*
+        }
+        #where_clause;
+    };
+
+    TokenStream::from(struct_def)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+fn deduce_derive_attr(input: &syn::DeriveInput) -> proc_macro2::TokenStream {
+    let mut derives: Vec<proc_macro2::TokenStream> = Vec::new();
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+    for attr in &input.attrs {
+        if attr.path().is_ident("derive") {
+            let _ = attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("Debug") {
+                    derives.push(quote! { Debug });
+                }
+                if meta.path.is_ident("Clone") {
+                    derives.push(quote! { Clone });
+                }
+                Ok(())
+            });
+        }
+    }
+
+    if derives.is_empty() {
+        quote! {}
+    } else {
+        quote! { #[derive( #(#derives),* )] }
+    }
+}
+
+/// Detect whether a given type is `Option<...>`
+///
+/// Heuristic:
+/// - Must be a `Type::Path`
+/// - Last path segment ident equals `Option`
+/// - Has angle-bracketed generic arguments
+fn is_option_type(ty: &Type) -> bool {
+    match ty {
+        Type::Path(TypePath { path, .. }) => is_path_option(path),
+        _ => false,
+    }
+}
+
+fn is_path_option(path: &Path) -> bool {
+    if let Some(last) = path.segments.last() {
+        last.ident == "Option" && matches!(last.arguments, PathArguments::AngleBracketed(_))
+    } else {
+        false
     }
 }


### PR DESCRIPTION

This basic implementation supports only struct types with named fields.
I don't vouch for generics support, nor any more complicated type.

It seemingly works with fields that are already of `Option` type,
however to detect that case it relies on a heuristic I'm not sure is
100% correct (likely it isn't - e.g. when a type is a macro and it
expands to an option type).
